### PR TITLE
Fix issue when there is no gas supplied by OVO

### DIFF
--- a/ovoenergy/ovoenergy.py
+++ b/ovoenergy/ovoenergy.py
@@ -97,7 +97,7 @@ class OVOEnergy:
 
         if "gas" in json_response:
             gas = json_response["gas"]
-            if "data" in gas:
+            if gas and "data" in gas:
                 gas_usage = []
                 for usage in gas["data"]:
                     gas_usage.append(


### PR DESCRIPTION
# Description
The following errors are logged when there is no Gas supplied by OVO, therefore the Gas object is 'None'.

```
2020-08-12 19:01:55 ERROR (MainThread) [homeassistant.components.ovo_energy] Unexpected error fetching sensor data: argument of type 'NoneType' is not iterable
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 143, in async_refresh
    self.data = await self._async_update_data()
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 131, in _async_update_data
    return await self.update_method()
  File "/usr/src/homeassistant/homeassistant/components/ovo_energy/__init__.py", line 43, in async_update_data
    return await client.get_daily_usage(now.strftime("%Y-%m"))
  File "/usr/local/lib/python3.8/site-packages/ovoenergy/ovoenergy.py", line 100, in get_daily_usage
    if "data" in gas:
TypeError: argument of type 'NoneType' is not iterable
2020-08-12 19:01:55 ERROR (MainThread) [homeassistant.components.sensor] Error while setting up ovo_energy platform for sensor
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 184, in _async_setup_platform
    await asyncio.shield(task)
  File "/usr/src/homeassistant/homeassistant/components/ovo_energy/sensor.py", line 30, in async_setup_entry
    currency = coordinator.data.electricity[
AttributeError: 'NoneType' object has no attribute 'electricity'
```

Note that this code generates a number of flake8 linting errors which I have not corrected, since already present. Most relevant is this:

`if response.status is not 200` should be changed to `if response.status != 200`

## Related issues this fixes
https://github.com/home-assistant/core/issues/38805 


## Checklist

<!-- Remember! You can check these boxes later after posting your PR -->

- [X] Change has been tested and works on my device(s).
- [X] Linters have been run.<!-- This is handled by the GitLab CI server as preflight checks. Make sure to fix any errors found -->
- [X] I am ready to merge.<!-- You can set the title to 'WIP: My PR' to stop merge early -->
