### PR TITLE
Add support for choosing account ID

### DIFF
--- a/ovoenergy/cli.py
+++ b/ovoenergy/cli.py
@@ -9,17 +9,18 @@ from ovoenergy.ovoenergy import OVOEnergy
 @click.command()
 @click.option("--username", "-u", help="Username")
 @click.option("--password", "-p", help="Password")
+@click.option("--account", "-a", help="Account Number")
 @click.option("--date", "-D", help="Date")
 @click.option("--daily", "-d", is_flag=True, help="Daily usage")
 @click.option("--halfhour", "-h", is_flag=True, help="Half hourly usage")
-def cli(username, password, date, daily=True, halfhour=False):
+def cli(username, password, account, date, daily=True, halfhour=False):
     """CLI for this package."""
-    asyncio.run(handle(username, password, date, daily, halfhour))
+    asyncio.run(handle(username, password, account, date, daily, halfhour))
 
 
-async def handle(username, password, date, daily=True, halfhour=False) -> None:
+async def handle(username, password, account, date, daily=True, halfhour=False) -> None:
     client = OVOEnergy()
-    authenticated = await client.authenticate(username, password)
+    authenticated = await client.authenticate(username, password, account)
     print(f"Authenticated: {authenticated}")
     if authenticated:
         print("Authenticated.")

--- a/ovoenergy/ovoenergy.py
+++ b/ovoenergy/ovoenergy.py
@@ -21,11 +21,12 @@ class OVOEnergy:
     def __init__(self) -> None:
         """Initilalize."""
         self._account_id = None
+        self._account_ids = None
         self._cookies = None
         self._customer_id = None
         self._username = None
 
-    async def authenticate(self, username, password) -> bool:
+    async def authenticate(self, username, password, account=None) -> bool:
         """Authenticate."""
         async with aiohttp.ClientSession() as session:
             response = await session.post(
@@ -56,7 +57,15 @@ class OVOEnergy:
                 )
                 json_response = await response.json()
                 if "accountIds" in json_response:
-                    self._account_id = json_response["accountIds"][0]
+                    self._account_ids = json_response["accountIds"]
+
+                    if account:
+                        if account in self._account_ids:
+                            self._account_id = account
+                        else:
+                            return False
+                    else:
+                        self._account_id = self._account_ids[0]
                 if "customerId" in json_response:
                     self._customer_id = json_response["customerId"]
                 self._username = username
@@ -247,6 +256,17 @@ class OVOEnergy:
     @property
     def account_id(self):
         return self._account_id
+
+    @account_id.setter
+    def account_id(self, new_account):
+        if new_account in self._account_ids:
+            self._account_id = new_account
+        else:
+            print("Invalid account ID")
+
+    @property
+    def account_ids(self):
+        return self._account_ids
 
     @property
     def customer_id(self):


### PR DESCRIPTION
# Proposed Changes

The code currently just chooses the first account ID returned when logging in, which doesn't allow for multiple accounts. This PR adds the ability to optionally pass in an account ID to use instead, as well as the ability to return all IDs.

## Related Issues

[https://github.com/timmo001/ovoenergy/issues/47]

## Checklist

<!-- Remember! You can check these boxes later after posting your PR -->

- [x] Change has been tested and works on my device(s).

<!-- All other checks are handled by the CI server as preflight checks.
     Make sure to fix any errors found.
     Your PR will not be merged if fixable errors are not resolved -->
