### PR TITLE
Add code to fetch raw meter readings

### DIFF
--- a/ovoenergy/__main__.py
+++ b/ovoenergy/__main__.py
@@ -95,6 +95,7 @@ def plan(
         fg=typer.colors.GREEN,
     )
 
+
 @app.command(name="readings", short_help="Get latest readings from OVO Energy")
 def readings(
     username: str = typer.Option(..., help="OVO Energy username"),
@@ -115,6 +116,7 @@ def readings(
         ovo_readings.json() if ovo_readings is not None else '{"message": "No data"}',
         fg=typer.colors.GREEN,
     )
+
 
 @app.command(name="carbon-footprint", short_help="Get carbon footprint from OVO Energy")
 def carbon_footprint(

--- a/ovoenergy/__main__.py
+++ b/ovoenergy/__main__.py
@@ -96,7 +96,7 @@ def plan(
     )
 
 @app.command(name="readings", short_help="Get latest readings from OVO Energy")
-def plan(
+def readings(
     username: str = typer.Option(..., help="OVO Energy username"),
     password: str = typer.Option(..., help="OVO Energy password"),
     account: str = typer.Option(None, help="OVO Energy account number"),

--- a/ovoenergy/__main__.py
+++ b/ovoenergy/__main__.py
@@ -8,7 +8,7 @@ from typing import Optional
 import typer
 
 from ._version import __version__
-from .models import OVODailyUsage, OVOHalfHourUsage
+from .models import OVODailyUsage, OVOHalfHourUsage, OVOReadings
 from .models.carbon_intensity import OVOCarbonIntensity
 from .models.footprint import OVOFootprint
 from .models.plan import OVOPlan
@@ -95,6 +95,26 @@ def plan(
         fg=typer.colors.GREEN,
     )
 
+@app.command(name="readings", short_help="Get latest readings from OVO Energy")
+def plan(
+    username: str = typer.Option(..., help="OVO Energy username"),
+    password: str = typer.Option(..., help="OVO Energy password"),
+    account: str = typer.Option(None, help="OVO Energy account number"),
+) -> None:
+    """Get rates from OVO Energy."""
+    ovo_readings: Optional[OVOReadings] = None
+
+    client = OVOEnergy()
+    authenticated = loop.run_until_complete(
+        client.authenticate(username, password, account)
+    )
+    if authenticated:
+        ovo_readings = loop.run_until_complete(client.get_latest_readings())
+
+    typer.secho(
+        ovo_readings.json() if ovo_readings is not None else '{"message": "No data"}',
+        fg=typer.colors.GREEN,
+    )
 
 @app.command(name="carbon-footprint", short_help="Get carbon footprint from OVO Energy")
 def carbon_footprint(

--- a/ovoenergy/models/__init__.py
+++ b/ovoenergy/models/__init__.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Optional
 
-from pydantic import BaseModel, Extra, Field, AliasChoices  # pylint: disable=no-name-in-module
+from pydantic import (
+    BaseModel,
+    Extra,
+    Field,
+    AliasChoices,
+)  # pylint: disable=no-name-in-module
 
 
 class OVOBase(BaseModel):
@@ -87,12 +92,14 @@ class OVOPlan(OVOBase):
     unit_rate: Optional[float] = Field(None, alias="unitRate")
     tariff: Optional[str] = Field(None, alias="tariff")
 
+
 class OVOReading(OVOBase):
     """Reading model."""
 
     reading_date: datetime = Field(None, alias="readingDateTime")
     reading_type: str = Field(None, alias="readingType")
-    reading: float = Field(None, alias=AliasChoices("gasVolume","reading"))
+    reading: float = Field(None, alias=AliasChoices("gasVolume", "reading"))
+
 
 class OVOReadings(OVOBase):
     """Readings model."""

--- a/ovoenergy/models/__init__.py
+++ b/ovoenergy/models/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Optional
 
-from pydantic import BaseModel, Extra, Field  # pylint: disable=no-name-in-module
+from pydantic import BaseModel, Extra, Field, AliasChoices  # pylint: disable=no-name-in-module
 
 
 class OVOBase(BaseModel):
@@ -86,3 +86,16 @@ class OVOPlan(OVOBase):
     standing_charge: Optional[float] = Field(None, alias="standingCharge")
     unit_rate: Optional[float] = Field(None, alias="unitRate")
     tariff: Optional[str] = Field(None, alias="tariff")
+
+class OVOReading(OVOBase):
+    """Reading model."""
+
+    reading_date: datetime = Field(None, alias="readingDateTime")
+    reading_type: str = Field(None, alias="readingType")
+    reading: float = Field(None, alias=AliasChoices("gasVolume","reading"))
+
+class OVOReadings(OVOBase):
+    """Readings model."""
+
+    electricity: OVOReading = Field(None, alias="electricity")
+    gas: OVOReading = Field(None, alias="gas")

--- a/ovoenergy/ovoenergy.py
+++ b/ovoenergy/ovoenergy.py
@@ -13,7 +13,7 @@ from .models import (
     OVOHalfHour,
     OVOHalfHourUsage,
     OVOReadings,
-    OVOReading
+    OVOReading,
 )
 from .models.carbon_intensity import OVOCarbonIntensity
 from .models.footprint import OVOFootprint
@@ -192,10 +192,11 @@ class OVOEnergy:
                 )
                 json_response = await response.json()
                 if len(json_response) > 0:
-                    if 'tiers' in json_response[0]:
-                        json_response[0]['reading'] = sum([t['meterRegisterReading'] for t in json_response[0]['tiers']])
+                    if "tiers" in json_response[0]:
+                        json_response[0]["reading"] = sum(
+                            t["meterRegisterReading"] for t in json_response[0]["tiers"]
+                        )
                     ovo_readings.electricity = OVOReading(**json_response[0])
-
 
         if plan.gas is not None:
             async with aiohttp.ClientSession() as session:


### PR DESCRIPTION
# Proposed Changes

It's sometimes useful to have raw meter readings, a number that always (OK, almost always) increases, e.g. to avoid duplication in readings in the Home Assistant energy dashboard. This is hopefully a step towards that.